### PR TITLE
show properties deviceID and vendorID as hex values

### DIFF
--- a/vulkanDeviceInfo.hpp
+++ b/vulkanDeviceInfo.hpp
@@ -291,8 +291,11 @@ public:
         properties["apiVersion"] = props.apiVersion;
         properties["apiVersionText"] = QString::fromStdString(vulkanResources::versionToString(props.apiVersion));
         properties["headerversion"] = VK_HEADER_VERSION;
-        properties["vendorID"] = props.vendorID;
-        properties["deviceID"] = props.deviceID;
+        QString hexID = "";
+        hexID.setNum(props.vendorID, 16);
+        properties["vendorID"] = hexID;
+        hexID.setNum(props.deviceID, 16);
+        properties["deviceID"] = hexID;
         properties["deviceType"] = props.deviceType;
         properties["deviceTypeText"] = QString::fromStdString(vulkanResources::physicalDeviceTypeString(props.deviceType));
 


### PR DESCRIPTION
Device and vendor IDs are derived from the respective PCI SIG IDs, commonly represented in hexadecimal values.