### PR TITLE
Fix QVariant(VkDeviceSize&) is ambiguous

### DIFF
--- a/vulkanDeviceInfo.hpp
+++ b/vulkanDeviceInfo.hpp
@@ -506,7 +506,7 @@ public:
                     deviceProps2.pNext = &extProps;
                     pfnGetPhysicalDeviceProperties2KHR(device, &deviceProps2);
                     properties2.push_back(Property2("maxPerSetDescriptors", QVariant(extProps.maxPerSetDescriptors), extName));
-                    properties2.push_back(Property2("maxMemoryAllocationSize", QVariant(extProps.maxMemoryAllocationSize), extName));
+                    properties2.push_back(Property2("maxMemoryAllocationSize", QVariant::fromValue(extProps.maxMemoryAllocationSize), extName));
                 }
             }
         }


### PR DESCRIPTION
On Archlinux with gcc gcc 8.1 calling QVariant(uint64_t) causes an error
call of overloaded 'QVariant(VkDeviceSize&)' is ambiguous