### PR TITLE
Fix ambigious calls to QVariant()

### DIFF
--- a/vulkanDeviceInfo.hpp
+++ b/vulkanDeviceInfo.hpp
@@ -480,7 +480,7 @@ public:
             pfnGetPhysicalDeviceProperties2KHR(device, &deviceProps2);
             pushProperty2(extension, "maxTransformFeedbackStreams", QVariant(extProps.maxTransformFeedbackStreams));
             pushProperty2(extension, "maxTransformFeedbackBuffers", QVariant(extProps.maxTransformFeedbackBuffers));
-            pushProperty2(extension, "maxTransformFeedbackBufferSize", QVariant(extProps.maxTransformFeedbackBufferSize));
+            pushProperty2(extension, "maxTransformFeedbackBufferSize", QVariant::fromValue(extProps.maxTransformFeedbackBufferSize));
             pushProperty2(extension, "maxTransformFeedbackStreamDataSize", QVariant(extProps.maxTransformFeedbackStreamDataSize));
             pushProperty2(extension, "maxTransformFeedbackBufferDataSize", QVariant(extProps.maxTransformFeedbackBufferDataSize));
             pushProperty2(extension, "maxTransformFeedbackBufferDataStride", QVariant(extProps.maxTransformFeedbackBufferDataStride));
@@ -536,9 +536,9 @@ public:
             pushProperty2(extension, "maxRecursionDepth", QVariant(extProps.maxRecursionDepth));
             pushProperty2(extension, "maxShaderGroupStride", QVariant(extProps.maxShaderGroupStride));
             pushProperty2(extension, "shaderGroupBaseAlignment", QVariant(extProps.shaderGroupBaseAlignment));
-            pushProperty2(extension, "maxGeometryCount", QVariant(extProps.maxGeometryCount));
-            pushProperty2(extension, "maxInstanceCount", QVariant(extProps.maxInstanceCount));
-            pushProperty2(extension, "maxTriangleCount", QVariant(extProps.maxTriangleCount));
+            pushProperty2(extension, "maxGeometryCount", QVariant::fromValue(extProps.maxGeometryCount));
+            pushProperty2(extension, "maxInstanceCount", QVariant::fromValue(extProps.maxInstanceCount));
+            pushProperty2(extension, "maxTriangleCount", QVariant::fromValue(extProps.maxTriangleCount));
             pushProperty2(extension, "maxDescriptorSetAccelerationStructures", QVariant(extProps.maxDescriptorSetAccelerationStructures));
         }
         // VK_NV_mesh_shader
@@ -629,7 +629,7 @@ public:
                     deviceProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
                     deviceProps2.pNext = &extProps;
                     pfnGetPhysicalDeviceProperties2KHR(device, &deviceProps2);
-                    properties2.push_back(Property2("maxPerSetDescriptors", QVariant(extProps.maxPerSetDescriptors), extName));
+                    properties2.push_back(Property2("maxPerSetDescriptors", QVariant::fromValue(extProps.maxPerSetDescriptors), extName));
                     properties2.push_back(Property2("maxMemoryAllocationSize", QVariant::fromValue(extProps.maxMemoryAllocationSize), extName));
                 }
             }


### PR DESCRIPTION
This fixes all errors like the following:

```
vulkanDeviceInfo.hpp:483:120: error: call of overloaded ‘QVariant(VkDeviceSize&)’ is ambiguous
pushProperty2(extension, "maxTransformFeedbackBufferSize", QVariant(extProps.maxTransformFeedbackBufferSize));
```

My GCC:

```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-pc-linux-gnu/8.2.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /var/tmp/portage/sys-devel/gcc-8.2.0-r4/work/gcc-8.2.0/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/gcc-bin/8.2.0 --includedir=/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/include --datadir=/usr/share/gcc-data/x86_64-pc-linux-gnu/8.2.0 --mandir=/usr/share/gcc-data/x86_64-pc-linux-gnu/8.2.0/man --infodir=/usr/share/gcc-data/x86_64-pc-linux-gnu/8.2.0/info --with-gxx-include-dir=/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/include/g++-v8 --with-python-dir=/share/gcc-data/x86_64-pc-linux-gnu/8.2.0/python --enable-languages=c,c++,fortran --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo 8.2.0-r4 p1.5' --disable-esp --enable-libstdcxx-time --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-multilib --with-multilib-list=m32,m64 --disable-altivec --disable-fixed-point --enable-targets=all --enable-libgomp --disable-libmudflap --disable-libssp --disable-libmpx --disable-systemtap --enable-vtable-verify --enable-libvtv --enable-lto --without-isl --enable-libsanitizer --enable-default-pie --enable-default-ssp
Thread model: posix
gcc version 8.2.0 (Gentoo 8.2.0-r4 p1.5)
```