### PR TITLE
Improved behaviour if no surface extensions are detected.

### DIFF
--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -444,7 +444,12 @@ bool vulkanCapsViewer::initVulkan()
     // todo : wayland etc.
 #endif
 
-    std::vector<const char*> enabledExtensions = { VK_KHR_SURFACE_EXTENSION_NAME, surfaceExtension.c_str() };
+    std::vector<const char*> enabledExtensions = {};
+
+    if(!surfaceExtension.empty()) {
+        enabledExtensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+        enabledExtensions.push_back(surfaceExtension.c_str());
+    };
 
     // Get instance extensions
     instanceInfo.extensions.clear();

--- a/vulkansurfaceinfo.hpp
+++ b/vulkansurfaceinfo.hpp
@@ -39,6 +39,10 @@ struct VulkanSurfaceInfo
 
     void get(VkPhysicalDevice device, VkSurfaceKHR surface)
     {
+        if (!validSurface) {
+           return;
+        }
+
         //todo: error checking
         VkResult vkRes;
         vkRes = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device, surface, &capabilities);


### PR DESCRIPTION
Helps un-supported systems or systems without surface exts from failing to startup or hang during getting surface information. This is allows MoltenVk to work, minus any surface info.