### PR TITLE
Add support for VK_EXT_tooling_info

### DIFF
--- a/VulkanDeviceInfoExtensions.cpp
+++ b/VulkanDeviceInfoExtensions.cpp
@@ -439,6 +439,27 @@ void VulkanDeviceInfoExtensions::readExtendedProperties() {
     readPhysicalProperties_NVX();
 }
 
+void VulkanDeviceInfoExtensions::readToolProperties() {
+	if (extensionSupported("VK_EXT_tooling_info")) {
+		const char* extension = "VK_EXT_tooling_info";
+		VkPhysicalDeviceToolPropertiesEXT extProps { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT };
+
+		uint32_t toolCount;
+		std::vector<VkPhysicalDeviceToolPropertiesEXT> toolsProps;
+		VkResult r;
+		do{
+			pfnGetPhysicalDeviceToolPropertiesEXT(device, &toolCount, nullptr);
+			toolsProps.resize(toolCount);
+			r = pfnGetPhysicalDeviceToolPropertiesEXT(device, &toolCount, toolsProps.data());
+		} while (r == VK_INCOMPLETE);
+		toolsProps.resize(toolCount);
+
+		for (const auto& toolProps : toolsProps){
+			this->toolProperties[toolProps.name] = {toolProps.version, toolProps.purposes, toolProps.description, toolProps.layer};
+		}
+	}
+}
+
 VkPhysicalDeviceFeatures2 VulkanDeviceInfoExtensions::initDeviceFeatures2(void *pNext) {
     VkPhysicalDeviceFeatures2 features2{};
     features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;

--- a/VulkanDeviceInfoExtensions.h
+++ b/VulkanDeviceInfoExtensions.h
@@ -80,7 +80,7 @@ private:
     void readPhysicalProperties_NVX();
 
 public:
-    const uint32_t vkHeaderVersion = 129;
+    const uint32_t vkHeaderVersion = 130;
     std::vector<Feature2> features2;
     std::vector<Property2> properties2;
     std::vector<VkExtensionProperties> extensions;

--- a/VulkanDeviceInfoExtensions.h
+++ b/VulkanDeviceInfoExtensions.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <QVariant>
+#include <QMap>
 
 #include "vulkan/vulkan.h"
 #include "vulkanpfn.h"
@@ -47,6 +48,15 @@ struct Property2 {
     QVariant value;
     const char* extension;
     Property2(std::string n, QVariant val, const char* ext) : name(n), value(val), extension(ext) {}
+};
+
+struct ToolProperty {
+    std::string version;
+    VkToolPurposeFlagsEXT purposes;
+    std::string description;
+    std::string layer;
+    ToolProperty(){}
+    ToolProperty(std::string v, VkToolPurposeFlagsEXT p, std::string d, std::string l ) : version(v), purposes(p), description(d), layer(l) {}
 };
 
 class VulkanDeviceInfoExtensions
@@ -83,10 +93,12 @@ public:
     const uint32_t vkHeaderVersion = 130;
     std::vector<Feature2> features2;
     std::vector<Property2> properties2;
+    QMap<QString, ToolProperty> toolProperties;
     std::vector<VkExtensionProperties> extensions;
     VkPhysicalDevice device;
     void readExtendedFeatures();
     void readExtendedProperties();
+    void readToolProperties();
 };
 
 #endif // VULKANDEVICEINFOEXTENSIONS_H

--- a/vulkanDeviceInfo.h
+++ b/vulkanDeviceInfo.h
@@ -88,6 +88,7 @@ public:
     VkPhysicalDeviceMemoryProperties memoryProperties;
     VkPhysicalDeviceFeatures deviceFeatures;
     bool hasSubgroupProperties = false;
+    bool hasToolProperties = false;
     QVariantMap subgroupProperties;
     std::vector<VulkanQueueFamilyInfo> queueFamilies;
     std::vector<VulkanFormatInfo> formats;

--- a/vulkanpfn.cpp
+++ b/vulkanpfn.cpp
@@ -2,3 +2,4 @@
 
 PFN_vkGetPhysicalDeviceFeatures2KHR pfnGetPhysicalDeviceFeatures2KHR = nullptr;
 PFN_vkGetPhysicalDeviceProperties2KHR pfnGetPhysicalDeviceProperties2KHR = nullptr;
+PFN_vkGetPhysicalDeviceToolPropertiesEXT pfnGetPhysicalDeviceToolPropertiesEXT = nullptr;

--- a/vulkanpfn.h
+++ b/vulkanpfn.h
@@ -7,3 +7,4 @@
 
 extern PFN_vkGetPhysicalDeviceFeatures2KHR pfnGetPhysicalDeviceFeatures2KHR;
 extern PFN_vkGetPhysicalDeviceProperties2KHR pfnGetPhysicalDeviceProperties2KHR;
+extern PFN_vkGetPhysicalDeviceToolPropertiesEXT pfnGetPhysicalDeviceToolPropertiesEXT;


### PR DESCRIPTION
output might be bit misleading as it would lack the tools from Validation Layers if not enabled.
For the most part probably will be empty unless the driver feels like advertising some nonsense here...