### PR TITLE
Wayland support (for real this time)

### DIFF
--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -22,10 +22,14 @@ win32 {
 }
 linux:!android {
     LIBS += -lvulkan
-    QT += waylandclient
-    QT += x11extras
-    DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
-    DEFINES += VK_USE_PLATFORM_XCB_KHR
+    qtHaveModule(waylandclient) {
+        QT += waylandclient
+        DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+    }
+    qtHaveModule(x11extras) {
+        QT += x11extras
+        DEFINES += VK_USE_PLATFORM_XCB_KHR
+    }
     target.path = /usr/bin
     INSTALLS += target
     desktop.files = vulkanCapsViewer.desktop

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -22,10 +22,10 @@ win32 {
 }
 linux:!android {
     LIBS += -lvulkan
+    QT += waylandclient
     QT += x11extras
-    #x11 {
-        DEFINES += VK_USE_PLATFORM_XCB_KHR
-    #}
+    DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+    DEFINES += VK_USE_PLATFORM_XCB_KHR
     target.path = /usr/bin
     INSTALLS += target
     desktop.files = vulkanCapsViewer.desktop

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -435,13 +435,15 @@ bool vulkanCapsViewer::initVulkan()
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
       VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
 #endif
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+      VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
+#endif
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
       VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
       VK_KHR_XCB_SURFACE_EXTENSION_NAME,
 #endif
-      // todo : wayland etc.
     };
 
     std::vector<const char*> enabledExtensions = {};
@@ -585,6 +587,17 @@ bool vulkanCapsViewer::initVulkan()
                 surfaceCreateInfo.window = nativeWindow;
                 surfaceResult = vkCreateAndroidSurfaceKHR(vkInstance, &surfaceCreateInfo, NULL, &surface);
             }
+        }
+#endif
+
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+        if (surface_extension == VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
+            VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
+            surfaceCreateInfo.pNext = nullptr;
+            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+            surfaceCreateInfo.display = wl_display_connect(NULL);
+            surfaceCreateInfo.surface = nullptr;
+            surfaceResult = vkCreateWaylandSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
         }
 #endif
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -430,23 +430,25 @@ bool vulkanCapsViewer::initVulkan()
         instanceInfo.layers.push_back(layer);
 	}
 
-    surfaceExtension = "";
-
     // Platform specific surface extensions
-#if defined(_WIN32)
-    surfaceExtension = VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-    surfaceExtension = VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-    surfaceExtension = VK_KHR_XCB_SURFACE_EXTENSION_NAME;
-    // todo : wayland etc.
+    std::vector<std::string> surfaceExtensionsAvailable = {
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+      VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
 #endif
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+      VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+#endif
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+      VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+#endif
+      // todo : wayland etc.
+    };
 
     std::vector<const char*> enabledExtensions = {};
 
     if(!surfaceExtension.empty()) {
         enabledExtensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-        enabledExtensions.push_back(surfaceExtension.c_str());
+        enabledExtensions.push_back(surfaceExtensionsAvailable[0].c_str());
     };
 
     // Get instance extensions
@@ -568,6 +570,9 @@ bool vulkanCapsViewer::initVulkan()
         surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
         surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
 #endif
+
+    if (surfaceResult == VK_SUCCESS)
+        surfaceExtension = surfaceExtensionsAvailable[0];
 
     displayGlobalLayers(ui.treeWidgetGlobalLayers);
     displayGlobalExtensions();

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -1305,6 +1305,9 @@ void vulkanCapsViewer::displayDeviceSurfaceInfo(VulkanDeviceInfo &device)
         return;
     }
 
+    // Surface extension used
+    addTreeItem(treeWidget->invisibleRootItem(), "Surface extension", surfaceExtension);
+
     // Surface capabilities
     QTreeWidgetItem *surfaceCapsItem = addTreeItem(treeWidget->invisibleRootItem(), "Surface Capabilities", "");
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -529,66 +529,82 @@ bool vulkanCapsViewer::initVulkan()
     }
 
     // Create a surface
-    // todo: only if surfaceExtensions != ""
-    VkResult surfaceResult = VK_ERROR_INITIALIZATION_FAILED;
-    surface = VK_NULL_HANDLE;
+    for (auto surface_extension : surfaceExtensionsAvailable) {
+        VkResult surfaceResult = VK_ERROR_INITIALIZATION_FAILED;
+        surface = VK_NULL_HANDLE;
+
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
-        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-        surfaceCreateInfo.hinstance = GetModuleHandle(nullptr);
-        surfaceCreateInfo.hwnd = reinterpret_cast<HWND>(this->winId());
-        surfaceResult = vkCreateWin32SurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-
-    // Get a native window via JNI
-    // Qt doesn't offer access to this, so we have to do this manually
-    // Note: Purely based on countless hours of trial-and-error, need to check on other devices
-    // todo: cleanup, error checking
-
-    // Get window
-    QAndroidJniObject activity = QtAndroid::androidActivity();
-    QAndroidJniObject window;
-    if (activity.isValid())
-    {
-        window = activity.callObjectMethod("getWindow", "()Landroid/view/Window;");
-    }
-
-    if (window.isValid())
-    {
-
-        // Get a surface texture
-        QAndroidJniObject surfaceTexture = QAndroidJniObject("android/graphics/SurfaceTexture", "(I)V", jint(0));
-        qDebug() << surfaceTexture.isValid();
-
-        // Get a surface based on the texture
-        QAndroidJniObject surface("android/view/Surface", "(Landroid/graphics/SurfaceTexture;)V", surfaceTexture.object());
-        qDebug() << surface.isValid();
-
-        if (surfaceTexture.isValid())
-        {
-            // Create a native window from our surface that can be used to create the Vulkan surface
-            QAndroidJniEnvironment qjniEnv;
-            nativeWindow = ANativeWindow_fromSurface(qjniEnv, surface.object());
+        if (surface_extension == VK_KHR_WIN32_SURFACE_EXTENSION_NAME) {
+            VkWin32SurfaceCreateInfoKHR surfaceCreateInfo = {};
+            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+            surfaceCreateInfo.hinstance = GetModuleHandle(nullptr);
+            surfaceCreateInfo.hwnd = reinterpret_cast<HWND>(this->winId());
+            surfaceResult = vkCreateWin32SurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
         }
-    }
-
-    if (nativeWindow)
-    {
-        VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
-        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
-        surfaceCreateInfo.window = nativeWindow;
-        surfaceResult = vkCreateAndroidSurfaceKHR(vkInstance, &surfaceCreateInfo, NULL, &surface);
-    }
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-        VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
-        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-        surfaceCreateInfo.connection = QX11Info::connection();
-        surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
-        surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
 #endif
 
-    if (surfaceResult == VK_SUCCESS)
-        surfaceExtension = surfaceExtensionsAvailable[0];
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+        if (surface_extension == VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) {
+
+            // Get a native window via JNI
+            // Qt doesn't offer access to this, so we have to do this manually
+            // Note: Purely based on countless hours of trial-and-error, need to check on other devices
+            // todo: cleanup, error checking
+
+            // Get window
+            QAndroidJniObject activity = QtAndroid::androidActivity();
+            QAndroidJniObject window;
+            if (activity.isValid())
+            {
+                window = activity.callObjectMethod("getWindow", "()Landroid/view/Window;");
+            }
+
+            if (window.isValid())
+            {
+
+                // Get a surface texture
+                QAndroidJniObject surfaceTexture = QAndroidJniObject("android/graphics/SurfaceTexture", "(I)V", jint(0));
+                qDebug() << surfaceTexture.isValid();
+
+                // Get a surface based on the texture
+                QAndroidJniObject surface("android/view/Surface", "(Landroid/graphics/SurfaceTexture;)V", surfaceTexture.object());
+                qDebug() << surface.isValid();
+
+                if (surfaceTexture.isValid())
+                {
+                    // Create a native window from our surface that can be used to create the Vulkan surface
+                    QAndroidJniEnvironment qjniEnv;
+                    nativeWindow = ANativeWindow_fromSurface(qjniEnv, surface.object());
+                }
+            }
+
+            if (nativeWindow)
+            {
+                VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
+                surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
+                surfaceCreateInfo.window = nativeWindow;
+                surfaceResult = vkCreateAndroidSurfaceKHR(vkInstance, &surfaceCreateInfo, NULL, &surface);
+            }
+        }
+#endif
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+        if (surface_extension == VK_KHR_XCB_SURFACE_EXTENSION_NAME) {
+            VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
+            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+            surfaceCreateInfo.connection = QX11Info::connection();
+            surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
+            surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
+        }
+#endif
+
+        if (surfaceResult == VK_SUCCESS) {
+            surfaceExtension = surface_extension;
+            break;
+        }
+        else
+            surface = VK_NULL_HANDLE;
+    }
 
     displayGlobalLayers(ui.treeWidgetGlobalLayers);
     displayGlobalExtensions();

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -439,8 +439,7 @@ bool vulkanCapsViewer::initVulkan()
     surfaceExtension = VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
     surfaceExtension = VK_KHR_XCB_SURFACE_EXTENSION_NAME;
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    surfaceExtension = VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
+    // todo : wayland etc.
 #endif
 
     std::vector<const char*> enabledExtensions = {};
@@ -568,13 +567,6 @@ bool vulkanCapsViewer::initVulkan()
         surfaceCreateInfo.connection = QX11Info::connection();
         surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
         surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-        VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
-        surfaceCreateInfo.pNext = nullptr;
-        surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-        surfaceCreateInfo.display = wl_display_connect(NULL);
-        surfaceCreateInfo.surface = nullptr;
-        surfaceResult = vkCreateWaylandSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
 #endif
 
     displayGlobalLayers(ui.treeWidgetGlobalLayers);

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -431,7 +431,7 @@ bool vulkanCapsViewer::initVulkan()
 	}
 
     // Platform specific surface extensions
-    std::vector<std::string> surfaceExtensionsAvailable = {
+    std::vector<std::string> possibleSurfaceExtensions = {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
       VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
 #endif
@@ -446,10 +446,26 @@ bool vulkanCapsViewer::initVulkan()
 
     std::vector<const char*> enabledExtensions = {};
 
-    if(!surfaceExtension.empty()) {
+    uint32_t availableExtensionCount = 0;
+    vkEnumerateInstanceExtensionProperties(nullptr, &availableExtensionCount, nullptr);
+    std::vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
+    vkEnumerateInstanceExtensionProperties(nullptr, &availableExtensionCount, availableExtensions.data());
+
+    if (availableExtensionCount != 0) {
         enabledExtensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-        enabledExtensions.push_back(surfaceExtensionsAvailable[0].c_str());
     };
+
+    std::vector<std::string> surfaceExtensionsAvailable = {};
+
+    for (const std::string& possibleExtension : possibleSurfaceExtensions) {
+      for (const auto& availableExtension : availableExtensions) {
+        if (possibleExtension == availableExtension.extensionName) {
+          surfaceExtensionsAvailable.push_back(possibleExtension);
+          enabledExtensions.push_back(possibleExtension.c_str());
+          break;
+        }
+      }
+    }
 
     // Get instance extensions
     instanceInfo.extensions.clear();


### PR DESCRIPTION
#86 had many issues and was entirely unusable for multiple reasons (see the first commit for details)

This new version compiles support for both X11 and Wayland and chooses at runtime which one to use (it tests Wayland, and if it doesn't work it tests X11; doing it the other way around would use X11 on Wayland as virtually every Wayland compositor supports Xwayland).

The compiled binary has been tested and works on both X11 and on Wayland, and is valgrind-clean.

**Note:** ~~I am not very familiar with Qmake and I was unable to figure out how to auto-detect the presence of the Wayland libraries, which means that starting now the Qt5Wayland libs are required to build VulkanCapsViewer on Linux.~~
Edit: Both X11 and Wayland are now build-optional. If you want the runtime option to use them, you will need to make sure you have the corresponding package installed when compiling VulkanCapsViewer. The Wayland package is usually called `qt5-wayland` (Arch), `qt5-qtwayland-devel` (Fedora) or `qtwaylandclient5-dev` (Ubuntu), while the X11 package is called `qt5-x11extras` (Arch), `qt5-qtx11extras-devel` (Fedora) or `libqt5x11extras5-dev` (Ubuntu).
@SaschaWillems you should add that last part in the 2.2 release notes :wink: