### PR TITLE
Make XCB and Wayland surface detection and initialization smarter.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           echo ${TARGET_PLATFORM}
           PATH="/opt/qt512/bin:$PATH"
           CXX="clang++"
-          qmake DEFINES+=X11 CONFIG+=release PREFIX=/usr
+          qmake CONFIG+=release PREFIX=/usr
           make INSTALL_ROOT=appdir install ; find appdir/
           wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
           chmod a+x linuxdeployqt-continuous-x86_64.AppImage
@@ -70,7 +70,7 @@ jobs:
           echo ${TARGET_PLATFORM}
           PATH="/opt/qt512/bin:$PATH"
           CXX="clang++"
-          qmake DEFINES+=wayland CONFIG+=release PREFIX=/usr
+          qmake CONFIG+=release PREFIX=/usr
           make INSTALL_ROOT=appdir install ; find appdir/
           wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
           chmod a+x linuxdeployqt-continuous-x86_64.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
           sudo apt update
           sudo apt install libvulkan-dev
 
+      - name: Install Wayland headers
+        run: |
+          sudo apt update
+          sudo apt install libwayland-dev
+
       - name: Build
         env:
           TARGET_PLATFORM: wayland

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -21,13 +21,13 @@ win32 {
 }
 linux:!android {
     LIBS += -lvulkan
-    contains(DEFINES, X11) {
-        message("Building for X11")
+    qtHaveModule(x11extras) {
+        message("Enabling XCB surface support.")
         QT += x11extras
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
-    contains(DEFINES, WAYLAND) {
-        message("Building for Wayland")
+    qtHaveModule(waylandclient) {
+        message("Enabling Wayland surface support.")
         QT += waylandclient
         DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
     }

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -26,10 +26,12 @@ linux:!android {
         QT += x11extras
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
-    qtHaveModule(waylandclient) {
-        message("Enabling Wayland surface support.")
-        QT += waylandclient
-        DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+    packagesExist(wayland-client) {
+      qtHaveModule(waylandclient) {
+          message("Enabling Wayland surface support.")
+          QT += waylandclient
+          DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+      }
     }
     target.path = /usr/bin
     INSTALLS += target

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -673,11 +673,20 @@ bool vulkanCapsViewer::initVulkan()
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
         if (surface_extension == VK_KHR_XCB_SURFACE_EXTENSION_NAME) {
-            VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
-            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-            surfaceCreateInfo.connection = QX11Info::connection();
-            surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
-            surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
+            xcb_connection_t* connection = QX11Info::connection();
+
+            if (connection != nullptr) {
+                VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {
+                  .sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR,
+                  .pNext = nullptr,
+                  .flags = 0,
+                  .connection = connection,
+                  .window = static_cast<xcb_window_t>(this->winId()),
+                };
+                surfaceResult = vkCreateXcbSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
+            } else {
+                qDebug() << "Could not connect to XCB display.";
+            }
         }
 #endif
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -655,12 +655,19 @@ bool vulkanCapsViewer::initVulkan()
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
         if (surface_extension == VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
-            VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
-            surfaceCreateInfo.pNext = nullptr;
-            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-            surfaceCreateInfo.display = wl_display_connect(NULL);
-            surfaceCreateInfo.surface = nullptr;
-            surfaceResult = vkCreateWaylandSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
+            struct wl_display* display = wl_display_connect(NULL);
+            if (display != NULL) {
+                VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {
+                  .sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
+                  .pNext = nullptr,
+                  .flags = 0,
+                  .display = display,
+                  .surface = nullptr
+                };
+                surfaceResult = vkCreateWaylandSurfaceKHR(vkInstance, &surfaceCreateInfo, nullptr, &surface);
+            } else {
+                qDebug() << "Could not connect to Wayland display.";
+            }
         }
 #endif
 


### PR DESCRIPTION
This patch set checks for valid Wayland and XCB pointers before creating the surfaces to determine if the surface back end is working at runtime. This behaviour fixes #93 .

Furthermore the qmake build is updated so all available surface implementations are set to enabled. The current default is none, which leads to a crash. This fixes #108 .

I tested this on Arch Linux using GNOME Shell under both Wayland and X11. I get a XCB surface under X11 and a Wayland one under Wayland, as intended. The build only enables Wayland if `qt5-wayland` is installed, as intended.