### PR TITLE
Initialize surface member to NULL

### DIFF
--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -639,6 +639,7 @@ bool VulkanCapsViewer::initVulkan()
     pfnGetPhysicalDeviceSurfaceSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceSupportKHR"));
 
     // Create a surface
+    surface = VK_NULL_HANDLE;
     for (auto surface_extension : surfaceExtensionsAvailable) {
         VkResult surfaceResult = VK_ERROR_INITIALIZATION_FAILED;
         surface = VK_NULL_HANDLE;


### PR DESCRIPTION
I ran into this case of possibleSurfaceExtensions being empty. Then
the surface is being queried in VulkanDeviceInfo::readQueueFamilies()
and it crashes in the implementation because the pointer is invalid.

Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>