### PR TITLE
Fix: Enable VK_EXT_swapchain_color_space if available

### DIFF
--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -628,7 +628,8 @@ bool VulkanCapsViewer::initVulkan()
         if (strcmp(ext.extensionName, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) == 0) {
             deviceProperties2Available = true;
             enabledExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-            break;
+        } else if (strcmp(ext.extensionName, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0) {
+            enabledExtensions.push_back(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
         }
     }
 


### PR DESCRIPTION
According to https://github.com/KhronosGroup/Vulkan-Docs/issues/442/#issuecomment-276937906, implementations are not allowed to return any enum value from the `VK_EXT_swapchain_color_space` extension. Yet, if we look at http://vulkan.gpuinfo.org/listsurfaceformats.php, we can see that a lot of drivers still do.

However, some implementations, such as MoltenVK, properly conform to the spec. In those cases only surface formats with `VK_COLOR_SPACE_SRGB_NONLINEAR_EXT` were reported in the database. With this change, we conditionally enable the extension if its available to actually show all available surface formats.