### PR TITLE
Unbreak Wayland build after Vulkan-Headers update

### DIFF
--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -56,6 +56,10 @@
 #include <sys/utsname.h>
 #endif
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <wayland-client.h>
+#endif
+
 #ifdef VK_USE_PLATFORM_XCB_KHR
 #include <QX11Info>
 #endif


### PR DESCRIPTION
Regressed by cb75c422e529 via KhronosGroup/Vulkan-Headers@5177b119bbdf: `<vulkan/vulkan.h>` no longer bootlegs `<wayland-client.h>`.

```c++
$ qmake-qt5 DEFINES+=WAYLAND && make
[...]
vulkancapsviewer.cpp:765:41: error: use of undeclared identifier 'wl_display_connect'
            surfaceCreateInfo.display = wl_display_connect(NULL);
                                        ^
```
