### PR TITLE
Use POSIX uname function instead of QSysInfo for BSD Unix

### DIFF
--- a/vulkanCapsViewer.cpp
+++ b/vulkanCapsViewer.cpp
@@ -57,7 +57,8 @@
 #include <windows.h>
 #endif
 
-#ifdef __linux__
+#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(__linux__)
+#define USE_UTSNAME
 #include <sys/utsname.h>
 #endif
 
@@ -82,9 +83,17 @@ OSInfo getOperatingSystem()
 {
     // QSysInfo works for all supported operating systems
     OSInfo osInfo = {};
+    // GhostBSD - QSysInfo::productType().toStdString() returs "unknown"
+#ifndef USE_UTSNAME
     osInfo.name = QSysInfo::productType().toStdString();
-    osInfo.architecture = QSysInfo::buildCpuArchitecture().toStdString();
     osInfo.version = QSysInfo::productVersion().toStdString();
+#else
+    struct utsname n;
+    uname(&n);
+    osInfo.name = n.sysname;
+    osInfo.version = n.version;
+#endif
+    osInfo.architecture = QSysInfo::buildCpuArchitecture().toStdString();
     // The Qt version used does not detect Windows 11, so we use Win32 API to detect it via the build version
 #if defined(_WIN32)
     HMODULE hModule = LoadLibrary(TEXT("ntdll.dll"));


### PR DESCRIPTION
For GhostBSD we have OS "unknown" for Report.

https://vulkan.gpuinfo.org/displayreport.php?id=11527

We should use POSIX uname function instead of QSysInfo for BSD Unix

After fixing we have correct result:
https://vulkan.gpuinfo.org/displayreport.php?id=11577

Also, see #124