### PR TITLE
Fix surface page on linux

### DIFF
--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -27,7 +27,7 @@ linux:!android {
     LIBS += -lvulkan
     qtHaveModule(x11extras) {
         message("Supporting X11")
-        QT += x11extras
+        QT += gui-private
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
     qtHaveModule(waylandclient) {

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -32,8 +32,8 @@ linux:!android {
     }
     qtHaveModule(waylandclient) {
         message("Supporting Wayland")
-        DEFINES += VK_USE_PLATFORM_XCB_KHR
         QT += waylandclient
+        QT += gui-private
         DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
     }
     target.path = /usr/bin

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -25,13 +25,14 @@ win32 {
 }
 linux:!android {
     LIBS += -lvulkan
-    contains(DEFINES, X11) {
-        message("Building for X11")
+    qtHaveModule(x11extras) {
+        message("Supporting X11")
         QT += x11extras
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
-    contains(DEFINES, WAYLAND) {
-        message("Building for Wayland")
+    qtHaveModule(waylandclient) {
+        message("Supporting Wayland")
+        DEFINES += VK_USE_PLATFORM_XCB_KHR
         QT += waylandclient
         DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
     }

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -31,10 +31,12 @@ linux:!android {
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
     qtHaveModule(waylandclient) {
-        message("Supporting Wayland")
-        QT += waylandclient
-        QT += gui-private
-        DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+        packagesExist(wayland-client) {
+                message("Supporting Wayland")
+                QT += waylandclient
+                QT += gui-private
+                DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+	}
     }
     target.path = /usr/bin
     INSTALLS += target

--- a/vulkanDeviceInfo.h
+++ b/vulkanDeviceInfo.h
@@ -52,10 +52,6 @@
 #include <sys/system_properties.h>
 #endif
 
-#ifdef VK_USE_PLATFORM_XCB_KHR
-#include <QX11Info>
-#endif
-
 #include "vulkanandroid.h"
 
 struct OSInfo

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -57,7 +57,7 @@
 #endif
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-#include <QX11Info>
+#include <qpa/qplatformnativeinterface.h>
 #endif
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
@@ -781,11 +781,16 @@ bool VulkanCapsViewer::initVulkan()
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
         if (surface_extension == VK_KHR_XCB_SURFACE_EXTENSION_NAME) {
-            VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
-            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-            surfaceCreateInfo.connection = QX11Info::connection();
-            surfaceCreateInfo.window = static_cast<xcb_window_t>(this->winId());
-            surfaceResult = vkCreateXcbSurfaceKHR(vulkanContext.instance, &surfaceCreateInfo, nullptr, &vulkanContext.surface);
+            auto native = QGuiApplication::platformNativeInterface();
+            auto connection = static_cast<xcb_connection_t*>(native->nativeResourceForIntegration("connection"));
+            auto window = this->winId();
+            if(connection != NULL) {
+                VkXcbSurfaceCreateInfoKHR surfaceCreateInfo = {};
+                surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+                surfaceCreateInfo.connection = connection;
+                surfaceCreateInfo.window = (xcb_window_t)(intptr_t)window;
+                surfaceResult = vkCreateXcbSurfaceKHR(vulkanContext.instance, &surfaceCreateInfo, nullptr, &vulkanContext.surface);
+            }
         }
 #endif
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -61,6 +61,7 @@
 #endif
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <qpa/qplatformnativeinterface.h>
 #include <wayland-client.h>
 #endif
 
@@ -764,12 +765,17 @@ bool VulkanCapsViewer::initVulkan()
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
         if (surface_extension == VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
-            VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
-            surfaceCreateInfo.pNext = nullptr;
-            surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-            surfaceCreateInfo.display = wl_display_connect(NULL);
-            surfaceCreateInfo.surface = nullptr;
-            surfaceResult = vkCreateWaylandSurfaceKHR(vulkanContext.instance, &surfaceCreateInfo, nullptr, &vulkanContext.surface);
+            auto native = QGuiApplication::platformNativeInterface();
+            auto display = static_cast<wl_display*>(native->nativeResourceForWindow("display", NULL));
+	    auto surface = static_cast<wl_surface*>(native->nativeResourceForWindow("surface", reinterpret_cast<QWindow*>(this)));
+	    if(display != NULL && surface != NULL) {
+                VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};
+                surfaceCreateInfo.pNext = nullptr;
+                surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+                surfaceCreateInfo.display = display;
+                surfaceCreateInfo.surface = surface;
+                surfaceResult = vkCreateWaylandSurfaceKHR(vulkanContext.instance, &surfaceCreateInfo, nullptr, &vulkanContext.surface);
+            }
         }
 #endif
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -766,7 +766,7 @@ bool VulkanCapsViewer::initVulkan()
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
         if (surface_extension == VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
             auto native = QGuiApplication::platformNativeInterface();
-            auto display = static_cast<wl_display*>(native->nativeResourceForWindow("display", NULL));
+            auto display = static_cast<wl_display*>(native->nativeResourceForIntegration("display"));
 	    auto surface = static_cast<wl_surface*>(native->nativeResourceForWindow("surface", reinterpret_cast<QWindow*>(this)));
 	    if(display != NULL && surface != NULL) {
                 VkWaylandSurfaceCreateInfoKHR surfaceCreateInfo = {};


### PR DESCRIPTION
- Use qtHaveModule() function to look for wayland and xcb qt modules. No need to pass a define to it anymore that way. Currently if X11 or WAYLAND define isn't passed to qmake surface tab is always empty
- Use QPA to obtain api specific handles. QPA is more reliable way to get them, doesn't require fishy things like passing NULL as wayland surface to vkCreateWaylandSurfaceKHR. QPA itself is a private interface that doesn't maintain binary compatibility, but this at least shouldn't be a problem for AppImage afaict.
This should resolve issue #140