### PR TITLE
Do not include libwayland-client.so within AppImage for Linux/Wayland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           chmod a+x linuxdeployqt-continuous-x86_64.AppImage
           export VERSION=${TARGET_PLATFORM}
           cp vulkanCapsViewer.png appdir/usr/share/icons/hicolor/256x256/apps/vulkanCapsViewer.png
-          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/* -appimage
+          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/* -appimage -exclude-libs=libwayland-client.so
       - name: Upload
         if: github.ref == 'refs/heads/master'
         run: curl -T Vulkan_Caps_Viewer-wayland-x86_64.AppImage ftp://${{ secrets.FTP_USER_NAME }}:${{ secrets.FTP_PASS }}@${{ secrets.FTP_SERVER_NAME }}


### PR DESCRIPTION
This PR is related to the issue I reported in #164.

Comparison of extracted AppImages 3.27 (last working one) vs. 3.28 (first one where the issue is visible) shows that the later one includes libwayland-client.so library:
```
$ diff -qr vulkancapsviewer_3.27_linux64_wayland/ vulkancapsviewer_3.28_linux64_wayland/
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/AppRun and vulkancapsviewer_3.28_linux64_wayland/squashfs-root/AppRun differ
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/usr/bin/vulkanCapsViewer and vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/bin/vulkanCapsViewer differ
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/usr/lib/libdbus-1.so.3 and vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/lib/libdbus-1.so.3 differ
Only in vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/lib: libffi.so.6
Only in vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/lib: libwayland-client.so.0
Only in vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/share/doc: libffi6
Only in vulkancapsviewer_3.28_linux64_wayland/squashfs-root/usr/share/doc: libwayland-client0
```
That difference is result of change introduced in #155.

After removing libwayland-client.so delivered from AppImage, vulkanCapsViewer application starts without problem using Wayland library installed in the system.

This PR proposes to exclude libwayland-client.so from AppImage created for Linux/Wayland.
Content of AppImage created with proposed change compared with official app in version 3.27 - Wayland library is not included:
```
$ diff -qr vulkancapsviewer_3.27_linux64_wayland/ Vulkan_Caps_Viewer-wayland-x86_64/
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/AppRun and Vulkan_Caps_Viewer-wayland-x86_64/squashfs-root/AppRun differ
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/usr/bin/vulkanCapsViewer and Vulkan_Caps_Viewer-wayland-x86_64/squashfs-root/usr/bin/vulkanCapsViewer differ
Files vulkancapsviewer_3.27_linux64_wayland/squashfs-root/usr/lib/libdbus-1.so.3 and Vulkan_Caps_Viewer-wayland-x86_64/squashfs-root/usr/lib/libdbus-1.so.3 differ
Only in Vulkan_Caps_Viewer-wayland-x86_64/squashfs-root/usr/lib: libffi.so.6
Only in Vulkan_Caps_Viewer-wayland-x86_64/squashfs-root/usr/share/doc: libffi6
```

I tested this change on two systems (ArchLinux and Fedora Desktop 37) and it resolves the issue #164 on both of them.

Fixes: #164