### PR TITLE
Add flatpak manifest

### DIFF
--- a/flatpak/flatpak_install.patch
+++ b/flatpak/flatpak_install.patch
@@ -1,0 +1,21 @@
+diff --git a/vulkanCapsViewer.pro b/vulkanCapsViewer.pro
+index 68d3608..447103d 100644
+--- a/vulkanCapsViewer.pro
++++ b/vulkanCapsViewer.pro
+@@ -35,13 +35,13 @@ linux:!android {
+         QT += waylandclient
+         DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+     }
+-    target.path = /usr/bin
++    target.path = /app/bin
+     INSTALLS += target
+     desktop.files = vulkanCapsViewer.desktop
+-    desktop.path = /usr/share/applications
++    desktop.path = /app/share/applications
+     icon.extra = cp $$PWD/gfx/android_icon_256.png vulkanCapsViewer.png
+     icon.files = vulkanCapsViewer.png
+-    icon.path = /usr/share/icons/hicolor/256x256/apps/
++    icon.path = /app/share/icons/hicolor/256x256/apps/
+     INSTALLS += desktop icon
+ }
+ android {

--- a/flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
+++ b/flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
@@ -1,0 +1,21 @@
+app-id: org.vulkanCapsViewer.VulkanCapsViewer
+runtime: org.kde.Platform
+runtime-version: '5.15-22.08'
+sdk: org.kde.Sdk
+command: vulkanCapsViewer
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --filesystem=host
+  - --device=dri
+modules:
+  - name: vulkanCapsViewer
+    buildsystem: qmake
+    sources:
+      - type: git
+        url: https://github.com/SaschaWillems/VulkanCapsViewer.git
+        branch: master
+      - type: patch
+        path: flatpak_install.patch


### PR DESCRIPTION
This adds manifest to make a flatpak of VulkanCapsViewer. It has an advantage over appimage of not being coupled with particular glibc versions, because flatpak runtime provides own glibc. Potentially this manifest could be used to upload the app to Flathub, but this use case probably needs extra work.
Steps to test:
```
cd flatpak
flatpak-builder --user --install --force-clean flatpak-output org.vulkanCapsViewer.VulkanCapsViewer.yml
flatpak run org.vulkanCapsViewer.VulkanCapsViewer
```