### PR TITLE
Flatpak build on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
         with:
           manifest-path: flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
+          bundle: vulkanCapsViewer.flatpak
 
   build_macosx:
     name: Build macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,21 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: curl -T Vulkan_Caps_Viewer-wayland-x86_64.AppImage ftp://${{ secrets.FTP_USER_NAME }}:${{ secrets.FTP_PASS }}@${{ secrets.FTP_SERVER_NAME }}
 
+  build_flatpak:
+    name: Build Flatpak
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
+        with:
+          manifest-path: flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
+
   build_macosx:
     name: Build macOS
     runs-on: macos-12

--- a/flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
+++ b/flatpak/org.vulkanCapsViewer.VulkanCapsViewer.yml
@@ -14,8 +14,7 @@ modules:
   - name: vulkanCapsViewer
     buildsystem: qmake
     sources:
-      - type: git
-        url: https://github.com/SaschaWillems/VulkanCapsViewer.git
-        branch: master
+      - type: dir
+        path: ".."
       - type: patch
         path: flatpak_install.patch


### PR DESCRIPTION
The CI build will add artifact with zip file containing vulkanCapsViewer.flatpak. It can be installed like this:
`flatpak install --user vulkanCapsViewer.flatpak`

TODO: Potentially could also upload flatpak bundle to ftp like in other builds but perhaps it's better to use https://github.com/actions/upload-artifact ?