### PR TITLE
Permit to build APK compatible with Pico 4 XR headset

### DIFF
--- a/VulkanDeviceInfoExtensions.cpp
+++ b/VulkanDeviceInfoExtensions.cpp
@@ -109,7 +109,7 @@ void VulkanDeviceInfoExtensions::readPhysicalProperties_ARM() {
 		VkPhysicalDeviceSchedulingControlsPropertiesARM extProps { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM };
 		VkPhysicalDeviceProperties2 deviceProps2(initDeviceProperties2(&extProps));
 		vulkanContext.vkGetPhysicalDeviceProperties2KHR(device, &deviceProps2);
-		pushProperty2(extension, "schedulingControlsFlags", QVariant(extProps.schedulingControlsFlags));
+ 		pushProperty2(extension, "schedulingControlsFlags", QVariant((qulonglong)extProps.schedulingControlsFlags));
 	}
 	if (extensionSupported("VK_ARM_shader_core_builtins")) {
 		const char* extension("VK_ARM_shader_core_builtins");

--- a/VulkanDeviceInfoExtensions.cpp
+++ b/VulkanDeviceInfoExtensions.cpp
@@ -109,7 +109,7 @@ void VulkanDeviceInfoExtensions::readPhysicalProperties_ARM() {
 		VkPhysicalDeviceSchedulingControlsPropertiesARM extProps { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM };
 		VkPhysicalDeviceProperties2 deviceProps2(initDeviceProperties2(&extProps));
 		vulkanContext.vkGetPhysicalDeviceProperties2KHR(device, &deviceProps2);
- 		pushProperty2(extension, "schedulingControlsFlags", QVariant((qulonglong)extProps.schedulingControlsFlags));
+		pushProperty2(extension, "schedulingControlsFlags", QVariant(extProps.schedulingControlsFlags));
 	}
 	if (extensionSupported("VK_ARM_shader_core_builtins")) {
 		const char* extension("VK_ARM_shader_core_builtins");

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ android {
 
     defaultConfig {
         resConfig "en"
-        minSdkVersion = "31"
-        targetSdkVersion = "33"
+        minSdkVersion = "29"
+        targetSdkVersion = "29"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,6 @@ android {
     defaultConfig {
         resConfig "en"
         minSdkVersion = "29"
-        targetSdkVersion = "29"
+        targetSdkVersion = "33"
     }
 }


### PR DESCRIPTION
This patch changes 2 things that may be unrelated (individual commits):

- Fix a compilation error when building the app with Clang on Android (Passing an `unsigned long` to QVariant from Qt 5.15)
- Lower the minimal and target Android SDK to version 29 in the main Gradle file. This allows building the app for devices stuck on Android 10 (Pico 4 and Oculus Quest 1 headset for example) 