### PR TITLE
Fix Windows MinGW compiler missing Advapi32.lib

### DIFF
--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -21,7 +21,7 @@ win32 {
     } else {
         LIBS += "$$PWD/libs/vulkan/lib32/vulkan-1.lib"
     }
-    LIBS += Advapi32.lib
+    LIBS += -ladvapi32
 }
 linux:!android {
     LIBS += -lvulkan


### PR DESCRIPTION
[Why]
Building on Windows fails with missing Advapi32.lib when using compiler MinGW. It could build pass with compiler MSVC on Windows.

[How]
Link library advapi32.dll for compiler MSVC and MinGW from Windows\System32.

[Issue]
https://github.com/SaschaWillems/VulkanCapsViewer/issues/22