### PR TITLE
ui: fix minor spelling and consistency

### DIFF
--- a/vulkancapsviewer.ui
+++ b/vulkancapsviewer.ui
@@ -1382,7 +1382,7 @@ height: 24px;
          </widget>
          <widget class="QWidget" name="tab_12">
           <attribute name="title">
-           <string>Queue families</string>
+           <string>Queue Families</string>
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_15">
            <item>
@@ -1623,7 +1623,7 @@ height: 24px;
                  </column>
                  <column>
                   <property name="text">
-                   <string>Impementation</string>
+                   <string>Implementation</string>
                   </property>
                  </column>
                  <column>


### PR DESCRIPTION
Trivial issues found during Vulkan SDK testing.

"Impementation" was misspelled.

"Queue Families" had both words capitalized in one place, but one capitalized and the other lowercase in another place.