### PR TITLE
Fix for missing surface info on macOS and iOS

### DIFF
--- a/appleutils.mm
+++ b/appleutils.mm
@@ -1,7 +1,17 @@
-#ifdef VK_USE_PLATFORM_IOS_MVK
-// iOS Utility Functions
-#import <UIKit/UIKit.h>
+#ifdef VK_USE_PLATFORM_METAL_EXT
 
+#import <Foundation/Foundation.h>
+#import <QuartzCore/CAMetalLayer.h>
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+#include <UIKit/UIView.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+#import <Metal/Metal.h>
+#import <MetalKit/MetalKit.h>
 
 extern "C" void setWorkingFolderForiOS(void)
 {
@@ -20,6 +30,24 @@ extern "C" const char *getWorkingFolderForiOS(void)
     strncpy(cWorkingFolder, [myPath UTF8String], 512);
 
     return cWorkingFolder;
+}
+
+
+extern "C" void *makeViewMetalCompatible(void* handle)
+{
+#if TARGET_OS_IPHONE
+    UIView* view = (__bridge UIView*)handle;
+    assert([view isKindOfClass:[UIView class]]);
+
+    void *pLayer =(__bridge void*)view.layer;
+    return pLayer;
+#else
+    NSView* view = (__bridge NSView*)handle;
+    assert([view isKindOfClass:[NSView class]]);
+
+    void *pLayer = (__bridge void *)view.layer;
+    return pLayer;
+#endif
 }
 
 #endif

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -69,7 +69,8 @@ ios {
     TARGET = "Vulkan Caps Viewer"
     QMAKE_INFO_PLIST = iOS/Info.plist
     DEFINES += VK_USE_PLATFORM_METAL_EXT
-    LIBS += /Users/lunarg/dev/VulkanSDK/MoltenVK/MoltenVk.xcframework/ios-arm64/libMoltenVK.a
+    DEFINES += VK_USE_PLATFORM_MACOS_MVK
+    LIBS += $(VULKAN_SDK)/lib/MoltenVk.xcframework/ios-arm64/libMoltenVK.a
     LIBS += -framework QuartzCore
     OBJECTIVE_SOURCES += appleutils.mm
     ICON = $${PWD}/iOS/vulkanCapsViewer.png

--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -59,7 +59,7 @@ android {
         android/res/values/libs.xml
 }
 macx {
-    DEFINES += VK_USE_PLATFORM_MACOS_MVK
+    DEFINES += VK_USE_PLATFORM_METAL_EXT
     VULKAN_DYLIB = $(VULKAN_SDK)/lib/libvulkan.dylib
     LIBS += $$VULKAN_DYLIB -framework Cocoa -framework QuartzCore
     OBJECTIVE_SOURCES += appleutils.mm
@@ -68,7 +68,7 @@ macx {
 ios {
     TARGET = "Vulkan Caps Viewer"
     QMAKE_INFO_PLIST = iOS/Info.plist
-    DEFINES += VK_USE_PLATFORM_IOS_MVK
+    DEFINES += VK_USE_PLATFORM_METAL_EXT
     LIBS += /Users/lunarg/dev/VulkanSDK/MoltenVK/MoltenVk.xcframework/ios-arm64/libMoltenVK.a
     LIBS += -framework QuartzCore
     OBJECTIVE_SOURCES += appleutils.mm

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -675,13 +675,14 @@ bool VulkanCapsViewer::initVulkan()
         if (strcmp(ext.extensionName, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0) {
             enabledExtensions.push_back(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
         }
-    }
 
 #if defined(__APPLE__) && (VK_HEADER_VERSION >= 216)
-    instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-    //enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-    enabledExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        if(strcmp(ext.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) {
+            instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        }
 #endif
+    }
 
     instanceCreateInfo.ppEnabledExtensionNames = enabledExtensions.data();
     instanceCreateInfo.enabledExtensionCount = (uint32_t)enabledExtensions.size();
@@ -860,7 +861,7 @@ void VulkanCapsViewer::getGPUinfo(VulkanDeviceInfo *GPU, uint32_t id, VkPhysical
     }
 
     std::vector<const char*> enabledExtensions;
-#if defined(VK_USE_PLATFORM_MACOS_MVK) && (VK_HEADER_VERSION >= 216)
+#if defined(__APPLE__) && (VK_HEADER_VERSION >= 216)
     enabledExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 #endif
 

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -74,8 +74,10 @@
 #ifdef __APPLE__
 #include <vulkan/vulkan_metal.h>
 
-#ifdef VK_USE_PLATFORM_IOS_MVK
+
+#ifdef VK_USE_PLATFORM_METAL_EXT
 extern "C" const char *getWorkingFolderForiOS(void);
+extern "C" void *makeViewMetalCompatible(void* handle);
 #endif
 #endif
 
@@ -119,11 +121,8 @@ OSInfo getOperatingSystem()
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     osInfo.type = 2;
 #endif
-#if defined(VK_USE_PLATFORM_MACOS_MVK)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
     osInfo.type = 3;
-#endif
-#if defined(VK_USE_PLATFORM_IOS_MVK)
-    osInfo.type = 4;
 #endif
 
     return osInfo;
@@ -307,7 +306,7 @@ VulkanCapsViewer::VulkanCapsViewer(QWidget *parent)
 VulkanCapsViewer::~VulkanCapsViewer()
 {    
     // Free up hidden window used on Apple platforms
-#if defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
     if(pMetalSurrogate != nullptr)
         delete pMetalSurrogate;
 #endif
@@ -623,13 +622,9 @@ bool VulkanCapsViewer::initVulkan()
       VK_KHR_XCB_SURFACE_EXTENSION_NAME,
 #endif
         
-//#if defined(VK_USE_PLATFORM_MACOS_MVK)
-//    VK_MVK_MACOS_SURFACE_EXTENSION_NAME,
-//#endif
-//
-//#if defined(VK_USE_PLATFORM_IOS_MVK)
-//   VK_MVK_IOS_SURFACE_EXTENSION_NAME,
-//#endif
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    VK_EXT_METAL_SURFACE_EXTENSION_NAME,
+#endif
     };
 
     std::vector<const char*> enabledExtensions = {};
@@ -643,9 +638,6 @@ bool VulkanCapsViewer::initVulkan()
         enabledExtensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
     }
     
-#if __APPLE__
-    enabledExtensions.push_back("VK_EXT_metal_surface");
-#endif
 
     std::vector<std::string> surfaceExtensionsAvailable = {};
 
@@ -686,8 +678,8 @@ bool VulkanCapsViewer::initVulkan()
     }
 
 #if defined(__APPLE__) && (VK_HEADER_VERSION >= 216)
-    instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-    enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    //enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
     enabledExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 #endif
 
@@ -812,13 +804,16 @@ bool VulkanCapsViewer::initVulkan()
 #endif
 
 // This works for deskop and iOS devices
-#if __APPLE__
-        VkMetalSurfaceCreateInfoEXT info = {};
-        info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
-        info.pNext = nullptr;
-        info.pLayer = (void*)pMetalSurrogate->winId();
-        info.flags = 0;
-        vkCreateMetalSurfaceEXT(vulkanContext.instance, &info, nullptr, &vulkanContext.surface);
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+        if(surface_extension == VK_EXT_METAL_SURFACE_EXTENSION_NAME) {
+            pMetalSurrogate = new QVukanSurrogate;
+            VkMetalSurfaceCreateInfoEXT info = {};
+            info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+            info.pNext = nullptr;
+            info.pLayer = (void*)makeViewMetalCompatible((void*)pMetalSurrogate->winId());
+            info.flags = 0;
+            surfaceResult = vkCreateMetalSurfaceEXT(vulkanContext.instance, &info, nullptr, &vulkanContext.surface);
+        }
 #endif
 
         if (surfaceResult == VK_SUCCESS) {

--- a/vulkancapsviewer.h
+++ b/vulkancapsviewer.h
@@ -48,7 +48,7 @@
     extern "C" void setWorkingFolderForiOS(void);
 #endif
 
-#if defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
 // An unseen window for macOS and iOS that has a Metal surface
 // attached.
 class QVukanSurrogate: public QWindow
@@ -85,7 +85,7 @@ public:
 private:
     uint32_t instanceApiVersion;
     int selectedDeviceIndex = 0;
-#if defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
     QVukanSurrogate *pMetalSurrogate = nullptr;
 #endif    
     Ui::vulkanCapsViewerClass ui;


### PR DESCRIPTION
This PR adds the missing surface information on iOS and macOS machines. This is in Queue Families tab and the Surface tab.