### PR TITLE
ci: Update MacOS to latest OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
   build_macosx:
     name: Build macOS
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
> The macOS 12 runner image will be removed by December 3rd, 2024.
> ...
> Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest.