### PR TITLE
Add checks to qmake for wayland/x11

### DIFF
--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -25,15 +25,17 @@ win32 {
 }
 linux:!android {
     LIBS += -lvulkan
-    contains(DEFINES, X11) {
-        message("Building for X11")
+    qtHaveModule(x11extras) {
+        message("Supporting X11")
         LIBS += -lxcb
         DEFINES += VK_USE_PLATFORM_XCB_KHR
     }
-    contains(DEFINES, WAYLAND) {
-        message("Building for Wayland")
-        LIBS += -lwayland-client
-        DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+    qtHaveModule(waylandclient) {
+    	packagesExist(wayland-client) {
+            message("Supporting Wayland")
+            LIBS += -lwayland-client
+            DEFINES += VK_USE_PLATFORM_WAYLAND_KHR
+        }
     }
     target.path = /usr/bin
     INSTALLS += target


### PR DESCRIPTION
This makes surface page appear for me with my usual way of building with qmake/make without having to pass any extra defines to it. 