### PR TITLE
Fix stack frame corruption

### DIFF
--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -97,7 +97,7 @@ OSInfo getOperatingSystem()
         RtlGetVersionFN RtlGetVersion = reinterpret_cast<RtlGetVersionFN>(GetProcAddress(hModule, "RtlGetVersion"));
         if (RtlGetVersion) {
             RTL_OSVERSIONINFOW osVersionInfo = { 0 };
-            osVersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
+            osVersionInfo.dwOSVersionInfoSize = sizeof(osVersionInfo);
             if (RtlGetVersion(&osVersionInfo) == S_OK) {
                 if (osVersionInfo.dwBuildNumber >= 22000) {
                     osInfo.version = "11";


### PR DESCRIPTION
`RtlGetVersion` call was passing a stack-allocated `RTL_OSVERSIONINFOW` but size set to that of`RTL_OSVERSIONINFOEXW`.

call always causes (284-276) bytes overflow.