### PR TITLE
Enable Multi-ABI support for android builds

### DIFF
--- a/vulkanCapsViewer.pro
+++ b/vulkanCapsViewer.pro
@@ -77,8 +77,13 @@ ios {
     }
 
 DEPENDPATH += .
-MOC_DIR += ./GeneratedFiles/release
-OBJECTS_DIR += release
+android {
+    MOC_DIR = ./GeneratedFiles/release_$${QT_ARCH}
+    OBJECTS_DIR = release_$${QT_ARCH}
+} else {
+    MOC_DIR = ./GeneratedFiles/release
+    OBJECTS_DIR = release
+}
 UI_DIR += ./GeneratedFiles
 RCC_DIR += ./GeneratedFiles
 include(vulkanCapsViewer.pri)


### PR DESCRIPTION
The current Play Store release of VulkanCapsViewer supports only arm64-v8a devices, leaving out data for lower end 32bit Android devices in the database. This PR enables multi ABI builds by assigning separate object and moc directories for each ABI, which prevents file overwrites that cause link-time errors. Note that multi ABI support still needs to be manually selected in the Qt build settings. It would be great to add 32 bit support so developers can easily see Vulkan features on lower end android devices.