### PR TITLE
Add arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - arm
   pull_request:
     branches:
       - master
@@ -11,22 +12,34 @@ on:
 jobs:
   build_ubuntu_x11:
     name: Build Ubuntu X11
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.cfg.os }}
+    strategy:
+      matrix:
+        cfg:
+        - { os: ubuntu-22.04,     arch: x86_64 }
+        - { os: ubuntu-22.04-arm, arch: aarch64 }
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
-      - uses: jurplel/install-qt-action@v3
-        with:
-          version: 5.12.9
-          host: linux
-
       - name: Install Vulkan SDK
         run: |
           sudo apt update
           sudo apt install libvulkan-dev
+
+      - name: Install x86_64 Qt
+        uses: jurplel/install-qt-action@v3
+        if: ${{ matrix.cfg.arch == 'x86_64' }}
+        with:
+          version: 5.12.9
+          host: linux
+
+      - name: Install aarch64 Qt
+        if: ${{ matrix.cfg.arch == 'aarch64' }}
+        run: |
+          sudo apt install qt5-qmake qtbase5-dev libqt5gui5
 
       - name: Install libfuse
         run: |
@@ -42,33 +55,50 @@ jobs:
           CXX="clang++"
           qmake DEFINES+=X11 CONFIG+=release PREFIX=/usr
           make INSTALL_ROOT=appdir install ; find appdir/
-          wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-          chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+          wget -c -nv "https://github.com/q4a/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage"
+          chmod a+x linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage
           export VERSION=${TARGET_PLATFORM}
           cp vulkanCapsViewer.png appdir/usr/share/icons/hicolor/256x256/apps/vulkanCapsViewer.png
-          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/* -appimage
+          ./linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage appdir/usr/share/applications/* -appimage
       - name: Upload
         if: github.ref == 'refs/heads/master'
-        run: curl -T Vulkan_Caps_Viewer-X11-x86_64.AppImage ftp://${{ secrets.FTP_USER_NAME }}:${{ secrets.FTP_PASS }}@${{ secrets.FTP_SERVER_NAME }}
+        run: curl -T Vulkan_Caps_Viewer-X11-${{matrix.cfg.arch}}.AppImage ftp://${{ secrets.FTP_USER_NAME }}:${{ secrets.FTP_PASS }}@${{ secrets.FTP_SERVER_NAME }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: Vulkan_Caps_Viewer-X11-${{matrix.cfg.arch}}.AppImage.ci-${{ github.run_number }}
+          path: Vulkan_Caps_Viewer-X11-${{matrix.cfg.arch}}.AppImage
 
   build_ubuntu_wayland:
     name: Build Ubuntu Wayland
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.cfg.os }}
+    strategy:
+      matrix:
+        cfg:
+        - { os: ubuntu-22.04,     arch: x86_64 }
+        - { os: ubuntu-22.04-arm, arch: aarch64 }
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
-      - uses: jurplel/install-qt-action@v3
-        with:
-          version: 5.12.9
-          host: linux
-
       - name: Install Vulkan SDK
         run: |
           sudo apt update
           sudo apt install libvulkan-dev libwayland-dev
+
+      - name: Install x86_64 Qt
+        uses: jurplel/install-qt-action@v3
+        if: ${{ matrix.cfg.arch == 'x86_64' }}
+        with:
+          version: 5.12.9
+          host: linux
+
+      - name: Install aarch64 Qt
+        if: ${{ matrix.cfg.arch == 'aarch64' }}
+        run: |
+          sudo apt install qt5-qmake qtbase5-dev libqt5gui5
 
       - name: Install libfuse
         run: |
@@ -84,14 +114,19 @@ jobs:
           CXX="clang++"
           qmake DEFINES+=WAYLAND CONFIG+=release PREFIX=/usr
           make INSTALL_ROOT=appdir install ; find appdir/
-          wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-          chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+          wget -c -nv "https://github.com/q4a/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage"
+          chmod a+x linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage
           export VERSION=${TARGET_PLATFORM}
           cp vulkanCapsViewer.png appdir/usr/share/icons/hicolor/256x256/apps/vulkanCapsViewer.png
-          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/* -appimage -exclude-libs=libwayland-client.so
+          ./linuxdeployqt-continuous-${{matrix.cfg.arch}}.AppImage appdir/usr/share/applications/* -appimage -exclude-libs=libwayland-client.so
       - name: Upload
         if: github.ref == 'refs/heads/master'
         run: curl -T Vulkan_Caps_Viewer-wayland-x86_64.AppImage ftp://${{ secrets.FTP_USER_NAME }}:${{ secrets.FTP_PASS }}@${{ secrets.FTP_SERVER_NAME }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: Vulkan_Caps_Viewer-wayland-${{matrix.cfg.arch}}.AppImage.ci-${{ github.run_number }}
+          path: Vulkan_Caps_Viewer-wayland-${{matrix.cfg.arch}}.AppImage
 
   build_macosx:
     name: Build macOS


### PR DESCRIPTION
Hi. I would like to add arm64 Linux support for VulkanCapsViewer.
I saw, that CI is using:
`https://github.com/probonopd/linuxdeployqt` - so I [added PR](https://github.com/probonopd/linuxdeployqt/pull/636) for it.
But there is also `jurplel/install-qt-action@v3` and looks like we can't use it for arm64 Linux:
it uses `aqtinstall`, which just download and install precompiled versions from qtsdkrepository.
Sad, but there is no Qt5 for arm64 in:
https://download.qt.io/online/qtsdkrepository/linux_arm64/desktop/ 
Only Qt >= 6.7.0

So I splited CI: x86_64 will use `jurplel/install-qt-action@v3`with old 5.12.9 and aarch64 will use Qt 5.15 from Ubuntu 22.04.
If you have any other suggestion - I can try to improve this PR.

And it's marked as draft because I need to clean some test commands and wait until `linuxdeployqt` will got arm64 support, but my [current test build](https://github.com/q4a/VulkanCapsViewer/actions/runs/15169577454) works fine and now I can upload my Vulkan stats directly from my SBC:
https://vulkan.gpuinfo.org/displayreport.php?id=39061