### PR TITLE
fix: avoid `using namespace std;` in header file

### DIFF
--- a/vulkandatabase.cpp
+++ b/vulkandatabase.cpp
@@ -33,6 +33,8 @@ QString VulkanDatabase::username = "";
 QString VulkanDatabase::password = "";
 QString VulkanDatabase::databaseUrl = "http://vulkan.gpuinfo.org/";
 
+using namespace std;
+
 bool VulkanDatabase::checkServerConnection(QString& message)
 {
     manager = new QNetworkAccessManager(nullptr);

--- a/vulkandatabase.h
+++ b/vulkandatabase.h
@@ -32,8 +32,6 @@
 
 #include "vulkanDeviceInfo.h"
 
-using namespace std;
-
 class VulkanDatabase :
 	public QObject
 {
@@ -41,8 +39,8 @@ class VulkanDatabase :
 private:
 	QNetworkProxy *proxy;
 	QNetworkAccessManager *manager;
-	string httpGet(string url);
-	string encodeUrl(string url);
+	std::string httpGet(std::string url);
+	std::string encodeUrl(std::string url);
 public:
     static QString username;
     static QString password;


### PR DESCRIPTION
using directive in a header file is a bad practice because it may lead to unexpected results.

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-using-directive