### PR TITLE
Pass parent widget into dialogs

### DIFF
--- a/settingsDialog.cpp
+++ b/settingsDialog.cpp
@@ -44,7 +44,7 @@ QCheckBox *createCheckBox(QString name)
 	return checkbox;
 }
 
-settingsDialog::settingsDialog(Settings appSet)
+settingsDialog::settingsDialog(QWidget *parent, Settings appSet) : QDialog(parent)
 {
 	appSettings = appSet;
 

--- a/settingsDialog.h
+++ b/settingsDialog.h
@@ -28,7 +28,7 @@ class settingsDialog : public QDialog
 private:
 	Settings appSettings;
 public:
-    settingsDialog(Settings appSet);
+    settingsDialog(QWidget *parent, Settings appSet);
 	~settingsDialog();
 private Q_SLOTS:
 	void slotAccept();

--- a/submitDialog.cpp
+++ b/submitDialog.cpp
@@ -31,7 +31,7 @@
 #include <QDialogButtonBox>
 #include <QCoreApplication>
 
-SubmitDialog::SubmitDialog(QString submitter, QString caption)
+SubmitDialog::SubmitDialog(QWidget *parent, QString submitter, QString caption) : QDialog(parent)
 {
 	QFormLayout *formLayout = new QFormLayout;
 

--- a/submitDialog.h
+++ b/submitDialog.h
@@ -32,7 +32,7 @@ private:
 	QLineEdit *editSubmitter;
 	QLineEdit *editComment;
 public:
-	SubmitDialog(QString submitter, QString caption = "Submit new report");
+	SubmitDialog(QWidget* parent, QString submitter, QString caption = "Submit new report");
 	~SubmitDialog();
 	QString getSubmitter();
 	QString getComment();

--- a/vulkancapsviewer.cpp
+++ b/vulkancapsviewer.cpp
@@ -421,7 +421,7 @@ void VulkanCapsViewer::slotUploadReport()
     }
     // Upload new report
     if (reportState == ReportState::not_present) {
-        SubmitDialog dialog(settings.submitterName, "Submit new report");
+        SubmitDialog dialog(this, settings.submitterName, "Submit new report");
         if (dialog.exec() == QDialog::Accepted) {
             QString message;
             QJsonObject reportJson;
@@ -441,7 +441,7 @@ void VulkanCapsViewer::slotUploadReport()
 
     // Update existing report
     if (reportState == ReportState::is_updatable) {
-        SubmitDialog dialog(settings.submitterName, "Update existing report");
+        SubmitDialog dialog(this, settings.submitterName, "Update existing report");
         if (dialog.exec() == QDialog::Accepted) {
             int reportId = database.getReportId(device);
             QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -477,7 +477,7 @@ void VulkanCapsViewer::slotUploadReport()
 
 void VulkanCapsViewer::slotSettings()
 {
-    settingsDialog dialog(settings);
+    settingsDialog dialog(this, settings);
     dialog.setModal(true);
     dialog.exec();
     settings.restore();


### PR DESCRIPTION
This PR adds a new constructor parameter to `settingsDialog` and `SubmitDialog` that passes the parent `QWidget` to the `QDialog` constructor.
On Wayland, this marks the dialogs' `xdg_toplevel` parent, which in turn helps tiling WMs (such as niri) identify them as floating, temporary dialogs and not give them proper tiling window status.

Before:
<img width="3420" height="1423" alt="Before" src="https://github.com/user-attachments/assets/c1fbbea4-295e-4b3f-952d-a6382d4b7e01" />
After:
<img width="1716" height="1421" alt="After" src="https://github.com/user-attachments/assets/388caca1-8271-41e2-9cbb-a65772bf5a5f" />
