### PR TITLE
cmake: fix linking in xcb and wayland libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # You must tell cmake where to find the Vulkan Headers and a loader library. For example on macOS:
 #
 # cmake .. -DVULKAN_LOADER_INSTALL_DIR=/Users/lunarg/VulkanSDK/1.3.230.0/macOS
-# cmake --build . --config Release  
+# cmake --build . --config Release
 
 cmake_minimum_required(VERSION 3.10.2)
 
@@ -12,7 +12,7 @@ if(WIN32)
     if(USE_STATIC_RT)
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
         message(STATUS "Vulkan Caps Viewer will link against static runtime on Windows")
-    endif()    
+    endif()
 endif()
 
 project(VK_CAPS_VIEWER LANGUAGES CXX)
@@ -42,16 +42,15 @@ if(NOT APPLE)
         add_executable(vulkanCapsViewer WIN32 ${FILES_ALL} ${FILES_UI})
         target_compile_definitions(vulkanCapsViewer PRIVATE _CRT_SECURE_NO_WARNINGS VK_USE_PLATFORM_WIN32_KHR)
     else()
-    	# Linux only
-	# find_package(Qt6 REQUIRED COMPONENTS x11extras QUIET)
- 	add_executable(vulkanCapsViewer ${FILES_ALL} ${FILES_UI})
- 	if(X11)
-	    target_compile_definitions(vulkanCapsViewer PRIVATE  VK_USE_PLATFORM_XCB_KHR)
-	endif()
-	if(WAYLAND)
-      find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
-	    target_compile_definitions(vulkanCapsViewer PRIVATE  VK_USE_PLATFORM_WAYLAND_KHR)	
-	endif()
+        # Linux only
+        add_executable(vulkanCapsViewer ${FILES_ALL} ${FILES_UI})
+        if(X11)
+            target_compile_definitions(vulkanCapsViewer PRIVATE  VK_USE_PLATFORM_XCB_KHR)
+        endif()
+        if(WAYLAND)
+            find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
+            target_compile_definitions(vulkanCapsViewer PRIVATE  VK_USE_PLATFORM_WAYLAND_KHR)
+        endif()
     endif()
 else()
     # APPLE only
@@ -88,15 +87,19 @@ if(NOT APPLE)
         target_link_libraries(vulkanCapsViewer Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network "${VULKAN_LOADER_INSTALL_DIR}/lib/vulkan-1.lib")
     else()
         # Linux...
-	if(X11)
-	    target_link_libraries(vulkanCapsViewer Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::x11extras "${VULKAN_LOADER_INSTALL_DIR}/lib/libvulkan.so")
-        elseif(WAYLAND)
-          target_link_libraries(vulkanCapsViewer Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::WaylandClient "${VULKAN_LOADER_INSTALL_DIR}/lib/libvulkan.so")
-        else()
-	    target_link_libraries(vulkanCapsViewer Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network "${VULKAN_LOADER_INSTALL_DIR}/lib/libvulkan.so")        
+        set(LINUX_LINK_LIBRARIES Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network "${VULKAN_LOADER_INSTALL_DIR}/lib/libvulkan.so")
+        if(X11)
+            find_package(X11 REQUIRED COMPONENTS xcb)
+            LIST(APPEND LINUX_LINK_LIBRARIES X11::xcb)
         endif()
+        if(WAYLAND)
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(WAYLAND_CLIENT REQUIRED IMPORTED_TARGET wayland-client)
+            LIST(APPEND LINUX_LINK_LIBRARIES Qt6::WaylandClient PkgConfig::WAYLAND_CLIENT)
+        endif()
+        target_link_libraries(vulkanCapsViewer ${LINUX_LINK_LIBRARIES})
     endif()
-else() 
+else()
     # APPLE
     target_link_libraries(vulkanCapsViewer "-framework Cocoa -framework QuartzCore")
 


### PR DESCRIPTION
Trying to compile vulkanCapsViewer using CMake with the params -DX11=YES and/or -DWAYLAND=YES would fail because the libraries were not being linked in. This change updates the cmake to link the appropriate libraries. Also, the file had a mix of CRLF and LF line endings, this commit updates to only have CRLF endings to be consistent with the repo. Also removed whitespace and updated indentation to be consistent.

CMakeLists.txt
- Run unix2dos on the file
- Updated formatting - indenting is consistent
- Remove an old comment
- Update logic if X11 or WAYLAND is specified and link appropriately in target_link_library calls